### PR TITLE
Add affiliation to homepage

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -2,7 +2,9 @@
 layout: about
 title: about
 permalink: /
-subtitle: <a href='#'>Affiliations</a>. Address. Contacts. Motto. Etc.
+subtitle: >-
+  Senior Research Associate, <a href="https://www.lcfi.ac.uk/">Leverhulme Centre for the
+  Future of Intelligence</a>, University of Cambridge
 
 profile:
   align: right


### PR DESCRIPTION
## Summary
- add Leverhulme Centre for the Future of Intelligence affiliation to homepage subtitle

## Testing
- `npx prettier --write _pages/about.md` *(fails: Cannot find package '@shopify/prettier-plugin-liquid')*
- `bundle exec jekyll build` *(fails: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68947b1b0404832abad503c6b8995527